### PR TITLE
Minor reconfiguration of example environment

### DIFF
--- a/environments/Example Environment.bru
+++ b/environments/Example Environment.bru
@@ -1,12 +1,12 @@
 vars {
-  api_server: fumage-example.canvasmedical.com
-  base_url: https://{{api_server}}
-  emr_base_url: https://example.canvasmedical.com
+  customer_identifier: 
+  domain: {{customer_identifier}}.canvasmedical.com
+  base_url: https://fumage-{{domain}}
+  emr_base_url: https://{{domain}}
   oauth_application_client_id: 
   fhir_access_token_expiration_datetime: 
-  patient_id: 
-  fhir_access_token: 
 }
 vars:secret [
-  oauth_application_client_secret
+  oauth_application_client_secret,
+  fhir_access_token
 ]


### PR DESCRIPTION
Changes:

* Added `customer_identifier` and `domain` so that the customer identifier only has to be entered once
* Removed `api_server`, since it wasn't really serving any purpose (it's only referenced once)
* Removed `patient_id`; there's also a `patient_id` collection variable, so I'm not sure what it means for there to be an environment variable too
