### PR TITLE
fix: fix reference format for patient id

### DIFF
--- a/DocumentReference/Create DocumentReference.bru
+++ b/DocumentReference/Create DocumentReference.bru
@@ -66,7 +66,7 @@ body:json {
           }
       ],
       "subject": {
-          "reference": "Patient{{patient_id}}",
+          "reference": "Patient/{{patient_id}}",
           "type": "Patient"
       },
       "author": [


### PR DESCRIPTION
Making a small update to the `DocumentReference/Create DocumentReference.bru` file, correcting the format of the `subject.reference` field by adding a slash between `Patient` and the patient ID.

Without this slash, the example fails API validation with a 400 and:

```
{
  "resourceType": "OperationOutcome",
  "issue": [
    {
      "severity": "error",
      "code": "value",
      "details": {
        "text": "body -> subject -> reference — must contain a resource type and identifier (type=value_error)"
      }
    }
  ]
}
```